### PR TITLE
Better Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ venv
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
+
+__pycache__
+*.pyc

--- a/venmo/__init__.py
+++ b/venmo/__init__.py
@@ -1,17 +1,19 @@
 import logging
 
-from venmo._version import __version__  # noqa
+from ._version import __version__  # noqa
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(name)s: %(levelname)s %(message)s')
 
 logging.getLogger('requests').setLevel(logging.WARNING)
 
-import auth        # noqa
-import cli         # noqa
-import cookies     # noqa
-import payment     # noqa
-import settings    # noqa
-import singletons  # noqa
-import types       # noqa
-import user        # noqa
+from . import (
+    auth,
+    cli,
+    cookies,
+    payment,
+    settings,
+    singletons,
+    types,
+    user
+)

--- a/venmo/cli.py
+++ b/venmo/cli.py
@@ -26,7 +26,7 @@ def status():
         User: youremailaddress
         Token: youraccesstoken
     '''
-    print '\n'.join([_version(), _credentials()])
+    print('\n'.join([_version(), _credentials()]))
 
 
 def _version():
@@ -95,7 +95,7 @@ def main():
     try:
         parse_args()
     except KeyboardInterrupt:
-        print ''
+        print('')
 
 
 if __name__ == '__main__':

--- a/venmo/cookies.py
+++ b/venmo/cookies.py
@@ -12,7 +12,7 @@ def save(requests_cookiejar):
     except OSError:
         pass  # It's okay if directory already exists
     with open(venmo.settings.COOKIES_FILE, 'wb') as f:
-        pickle.dump(requests_cookiejar, f)
+        pickle.dump(requests_cookiejar, f, -1)
 
 
 def load():

--- a/venmo/payment.py
+++ b/venmo/payment.py
@@ -4,9 +4,13 @@ Payment
 
 import logging
 import sys
-import urllib
-
 import requests
+
+# Python 2.x fixes
+try: from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 import venmo
 
 logger = logging.getLogger('venmo.payment')
@@ -56,7 +60,7 @@ def _pay_or_charge(user, amount, note):
         if 'error' in data:
             message = data['error']['message']
             error_message += ': "{}"'.format(message)
-        print error_message
+        print(error_message)
         sys.exit(1)
 
     payment = data['data']['payment']
@@ -75,12 +79,12 @@ def _pay_or_charge(user, amount, note):
     else:
         user = target[target['type']],
     note = payment['note']
-    print ('Successfully {payment_action} {user} ${amount:.2f} for "{note}"'
+    print('Successfully {payment_action} {user} ${amount:.2f} for "{note}"'
            .format(**locals()))
 
 
 def _payments_url_with_params(params):
     return '{payments_base_url}?{params}'.format(
         payments_base_url=venmo.settings.PAYMENTS_URL,
-        params=urllib.urlencode(params),
+        params=urlencode(params),
     )

--- a/venmo/user.py
+++ b/venmo/user.py
@@ -15,7 +15,7 @@ def id_from_username(username):
 
 
 def print_search(query):
-    print json.dumps(search(query), indent=4)
+    print(json.dumps(search(query), indent=4))
 
 
 def search(query):


### PR DESCRIPTION
Still having problems with Pickle. See here for more info on that. http://stackoverflow.com/questions/34571063/i-have-pickled-files-using-protocol-3-in-python3-and-now-i-need-to-unpickle-the/34571081

Otherwise, this seems to work with both Python 2 and 3. Hopefully you can sort out any remaining discrepancies.

Not supporting Python 3 is an issue because Python 2 is trying to reach EOL, and Python 3 now comes as the default on many systems. For my machine, I had to run `pip2 install venmo` in order for this application to work. The "pip" command installs in Python 3 mode.