### PR TITLE
Pass bearer token to search call

### DIFF
--- a/venmo/auth.py
+++ b/venmo/auth.py
@@ -280,6 +280,12 @@ def get_access_token():
         return None
 
 
+def ensure_access_token():
+    while not get_access_token():
+        logger.warn('No access token. Configuring ...')
+        configure()
+
+
 def read_config():
     config = configparser.RawConfigParser()
     config.read(venmo.settings.CREDENTIALS_FILE)

--- a/venmo/payment.py
+++ b/venmo/payment.py
@@ -21,12 +21,8 @@ def charge(user, amount, note):
 
 
 def _pay_or_charge(user, amount, note):
+    venmo.auth.ensure_access_token()
     access_token = venmo.auth.get_access_token()
-    if not access_token:
-        logger.warn('No access token. Configuring ...')
-        if not venmo.auth.configure():
-            return
-        access_token = venmo.auth.get_access_token()
 
     data = {
         'note': note,

--- a/venmo/user.py
+++ b/venmo/user.py
@@ -20,12 +20,16 @@ def print_search(query):
 
 
 def search(query):
+    venmo.auth.ensure_access_token()
     response = requests.get(
         venmo.settings.USERS_URL,
         params={
             'limit': 5,
             'query': query,
-        }
+        },
+        headers={
+            'Authorization': 'Bearer {}'.format(venmo.auth.get_access_token())
+        },
     )
     users = response.json()['data']
     results = []


### PR DESCRIPTION
Closes #53.

Venmo removed `id` from their unauthenticated search API. By passing a
bearer token to the search call, we receive `id`s once again.